### PR TITLE
修复 sphinx 包错误

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -25,7 +25,7 @@ import sys, os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.pngmath']
+extensions = ['sphinx.ext.imgmath']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
pngmath extension was deprecated at Sphinx-1.6 and removed at 1.8. Now sphinx.ext.imgmath is a successor of pngmath.